### PR TITLE
#38 メインページでの書籍取得API不具合修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,3 +13,5 @@ RUN go get -u gorm.io/gorm
 RUN echo 'alias prisma="go run github.com/steebchen/prisma-client-go"' >> ~/.bashrc
 
 COPY . /go/src
+
+CMD ["go", "run", "main.go"]

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewDB() *gorm.DB {
-	err := godotenv.Load("../.env")
+	err := godotenv.Load(".env")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -20,5 +20,5 @@ func main() {
 	userController := controller.NewUserController(userUsecase)
 	bookController := controller.NewBookController(bookUsecase)
 	e := router.NewRouter(userController, bookController)
-	e.Logger.Fatal(e.Start(":8081"))
+	e.Logger.Fatal(e.Start(":8080"))
 }


### PR DESCRIPTION
# 原因
- サーバ実行がコンテナ起動時にされていないため
# 対応
- コンテナ起動時にGoのサーバが起動されるように修正
- バックエンドリッスンポートを`:8080`に変更