### PR TITLE
#58 SchemaSpy導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 
 # air
 /backend/tmp
+
+# schemaspy
+/schemaspy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,36 @@ services:
     ports:
       - "4010:4010"
 
+  schemaspy:
+    image: schemaspy/schemaspy:snapshot
+    depends_on:
+      - db
+    volumes:
+      - ./schemaspy/output:/output
+    networks:
+      - app_network
+    # .envを参照するためschemaspy.propertiesは使用しない
+    command: >
+      java -jar schemaspy.jar
+      - vizjs
+      -t mysql
+      -dp mysql-connector-java.jar
+      -host db
+      -port ${MYSQL_PORT}
+      -db ${MYSQL_DATABASE}
+      -u ${MYSQL_USER}
+      -p ${MYSQL_PASSWORD}
+      -s ${MYSQL_DATABASE}
+
+  schemaspy_nginx:
+    image: nginx
+    depends_on:
+      - schemaspy
+    ports:
+      - 8088:80
+    volumes:
+      - ./schemaspy/output:/usr/share/nginx/html:ro
+
 volumes:
   mysql_data:
 


### PR DESCRIPTION
close #58 

## 対応
- `schemaspy`コンテナ実行でローカルDBの内容からテーブル定義書を出力できるようにした
- 暫定的にホスティングは`8088`ポートで設定
  - `S3 + CloudFront`または`GitHub Pages`に移管する予定

## スクショ
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/0f4e7d86-fd81-4253-8027-c6bb6f05681d" />
